### PR TITLE
Add ezpz MoE configurations and JSON override

### DIFF
--- a/configs/ezpz_test.json
+++ b/configs/ezpz_test.json
@@ -1,0 +1,18 @@
+{
+  "parallelism": {
+    "data_parallel_replicate_degree": 2,
+    "data_parallel_shard_degree": -1,
+    "tensor_parallel_degree": 1,
+    "pipeline_parallel_degree": 1,
+    "context_parallel_degree": 1
+  },
+  "training": {
+    "local_batch_size": 1,
+    "global_batch_size": 96,
+    "seq_len": 8096,
+    "steps": 100
+  },
+  "metrics": {
+    "log_freq": 1
+  }
+}

--- a/torchtitan/experiments/ezpz/agpt/config_registry.py
+++ b/torchtitan/experiments/ezpz/agpt/config_registry.py
@@ -1,3 +1,8 @@
+import json
+import os
+from dataclasses import is_dataclass
+from typing import Any
+
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
@@ -12,6 +17,8 @@ from torchtitan.experiments.ft.config.job_config import FaultTolerance
 from torchtitan.experiments.ft.trainer import FaultTolerantTrainer
 
 from . import model_registry
+
+TT_CONFIG_JSON_ENV = "TT_CONFIG_JSON"
 
 
 def _base_config(flavor: str) -> FaultTolerantTrainer.Config:
@@ -47,6 +54,54 @@ def _base_config(flavor: str) -> FaultTolerantTrainer.Config:
     )
 
 
+def _load_json_overrides() -> dict[str, Any]:
+    path = os.environ.get(TT_CONFIG_JSON_ENV, "").strip()
+    if not path:
+        raise ValueError(
+            f"{TT_CONFIG_JSON_ENV} must point to a JSON file when using *_from_json configs."
+        )
+
+    with open(path, encoding="utf-8") as f:
+        overrides = json.load(f)
+
+    if not isinstance(overrides, dict):
+        raise ValueError(
+            f"Expected top-level JSON object in {path!r}, got {type(overrides).__name__}."
+        )
+
+    return overrides
+
+
+def _apply_config_overrides(
+    target: Any,
+    overrides: dict[str, Any],
+    path: str = "",
+) -> None:
+    for key, value in overrides.items():
+        if not hasattr(target, key):
+            raise KeyError(f"Unknown config field {key!r} at path {path or '<root>'}.")
+
+        current_value = getattr(target, key)
+        field_path = f"{path}.{key}" if path else key
+
+        if isinstance(value, dict):
+            if not is_dataclass(current_value):
+                raise TypeError(
+                    f"Expected dataclass at {field_path!r} for nested override, "
+                    f"got {type(current_value).__name__}."
+                )
+            _apply_config_overrides(current_value, value, field_path)
+            continue
+
+        setattr(target, key, value)
+
+
+def _config_from_json(flavor: str) -> FaultTolerantTrainer.Config:
+    cfg = _base_config(flavor)
+    _apply_config_overrides(cfg, _load_json_overrides())
+    return cfg
+
+
 def ezpz_agpt_debugmodel() -> FaultTolerantTrainer.Config:
     return _base_config("debugmodel")
 
@@ -61,6 +116,22 @@ def ezpz_agpt_7b() -> FaultTolerantTrainer.Config:
 
 def ezpz_agpt_8b() -> FaultTolerantTrainer.Config:
     return _base_config("8B")
+
+
+def ezpz_agpt_debugmodel_from_json() -> FaultTolerantTrainer.Config:
+    return _config_from_json("debugmodel")
+
+
+def ezpz_agpt_2b_from_json() -> FaultTolerantTrainer.Config:
+    return _config_from_json("2b")
+
+
+def ezpz_agpt_7b_from_json() -> FaultTolerantTrainer.Config:
+    return _config_from_json("7b")
+
+
+def ezpz_agpt_8b_from_json() -> FaultTolerantTrainer.Config:
+    return _config_from_json("8B")
 
 
 def ezpz_agpt_blendcorpus_debugmodel() -> FaultTolerantTrainer.Config:

--- a/torchtitan/experiments/ezpz/agpt/parallelize.py
+++ b/torchtitan/experiments/ezpz/agpt/parallelize.py
@@ -2,7 +2,6 @@ import ezpz.dist
 
 import torch
 import torch.nn as nn
-from torch.distributed._composable.fsdp import FSDPModule
 from torch.distributed._composable.replicate import replicate
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard, MixedPrecisionPolicy
@@ -229,15 +228,29 @@ def apply_compile(model: nn.Module, compile_config: CompileConfig):
 def disable_fsdp_gradient_division(model: nn.Module) -> None:
     force_sum_reduction = False
     if torch.distributed.is_available() and torch.distributed.is_initialized():
-        backend = ezpz.dist.get_torch_backend()
-        if backend and backend.lower() != "nccl":
+        backend = ezpz.dist.get_torch_backend() or str(torch.distributed.get_backend())
+        if backend and "nccl" not in str(backend).lower():
             force_sum_reduction = True
 
+    fsdp_modules_updated = 0
     for module in model.modules():
-        if isinstance(module, FSDPModule):
-            module.set_gradient_divide_factor(1.0)
+        # Be resilient to FSDPModule class location changes across PyTorch releases.
+        set_divide_factor = getattr(module, "set_gradient_divide_factor", None)
+        if callable(set_divide_factor):
+            set_divide_factor(1.0)
+            fsdp_modules_updated += 1
             if force_sum_reduction:
-                module.set_force_sum_reduction_for_comms(True)
+                set_force_sum = getattr(
+                    module, "set_force_sum_reduction_for_comms", None
+                )
+                if callable(set_force_sum):
+                    set_force_sum(True)
+
+    logger.info(
+        "Configured FSDP gradient division for %d modules (force_sum_reduction=%s)",
+        fsdp_modules_updated,
+        force_sum_reduction,
+    )
 
 
 def apply_fsdp(

--- a/torchtitan/experiments/ezpz/moe_runs/README.md
+++ b/torchtitan/experiments/ezpz/moe_runs/README.md
@@ -1,0 +1,80 @@
+# DeepSeek V3 MoE Runs (Aurora / ezpz)
+
+This folder contains a starter setup for launching DeepSeek V3-style MoE runs with:
+
+- `expert_parallel_degree=12`
+- 2-node Aurora runs (`24` tiles total)
+- no TP/PP/CP sharding (`tp=pp=cp=1`)
+- one dense layer at the beginning (`n_dense_layers=1`)
+
+The config used by the launcher is loaded from `TT_CONFIG_JSON` and overlaid onto
+the `deepseek_v3_10b_2b_ep12` base config.
+
+By default, the launcher uses `assets/hf/gemma-7b` when available, and
+`deepseek_v3` model vocab size is automatically synced from the tokenizer files.
+
+## Files
+
+- `deepseek_v3_10b2b_ep12_2nodes.json`: JSON overrides
+- `deepseek_v3_10b2b_ep12_2nodes_smoke.json`: smoke-test JSON overrides (default)
+- `deepseek_v3_10b2b_ep12_2nodes_4096_perf.json`: 4096-seq throughput-oriented JSON
+- `launch_deepseek_v3_moe_ep12.sh`: launcher script
+
+The launcher now defaults to the smoke JSON, which uses:
+
+- `seq_len=1024`
+- `global_batch_size=24`
+- `steps=40`
+- `attn_backend=sdpa`
+- `compile.enable=false`
+- checkpoint save every 5 steps (`enable_first_step_checkpoint=true`)
+
+## Run
+
+From repository root:
+
+```bash
+torchtitan/experiments/ezpz/moe_runs/launch_deepseek_v3_moe_ep12.sh my_wandb_run_name
+```
+
+If tokenizer assets are not present yet:
+
+```bash
+python3 scripts/download_hf_assets.py --repo_id google/gemma-7b --assets tokenizer
+```
+
+You can also force a specific tokenizer/assets path:
+
+```bash
+HF_ASSETS_PATH=/abs/path/to/assets/hf/gemma-7b \
+torchtitan/experiments/ezpz/moe_runs/launch_deepseek_v3_moe_ep12.sh my_wandb_run_name
+```
+
+Optional additional TorchTitan args can be appended:
+
+```bash
+torchtitan/experiments/ezpz/moe_runs/launch_deepseek_v3_moe_ep12.sh my_wandb_run_name \
+  --training.steps 200 \
+  --checkpoint.interval 20
+```
+
+To use a different JSON file:
+
+```bash
+TT_CONFIG_JSON=/abs/path/to/overrides.json \
+torchtitan/experiments/ezpz/moe_runs/launch_deepseek_v3_moe_ep12.sh my_wandb_run_name
+```
+
+To use the non-smoke 4096-seq config:
+
+```bash
+TT_CONFIG_JSON=torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes.json \
+torchtitan/experiments/ezpz/moe_runs/launch_deepseek_v3_moe_ep12.sh my_wandb_run_name
+```
+
+To use the 4096-seq throughput-oriented config (no torch.compile, async checkpoint):
+
+```bash
+TT_CONFIG_JSON=torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_4096_perf.json \
+bash torchtitan/experiments/ezpz/moe_runs/launch_deepseek_v3_moe_ep12.sh my_wandb_run_name
+```

--- a/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_128nodes_4096_prod_sim_ac_lb2_compile_ffn.json
+++ b/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_128nodes_4096_prod_sim_ac_lb2_compile_ffn.json
@@ -1,0 +1,67 @@
+{
+  "training": {
+    "local_batch_size": 2,
+    "global_batch_size": 3072,
+    "seq_len": 4096,
+    "steps": 1000,
+    "gc_freq": 1000
+  },
+  "model_spec": {
+    "model": {
+      "layer": {
+        "attention": {
+          "attn_backend": "sdpa",
+          "attn_mask_type": "causal",
+          "qk_nope_head_dim": 64,
+          "qk_rope_head_dim": 64
+        }
+      }
+    }
+  },
+  "parallelism": {
+    "data_parallel_replicate_degree": 128,
+    "data_parallel_shard_degree": 12,
+    "tensor_parallel_degree": 1,
+    "pipeline_parallel_degree": 1,
+    "context_parallel_degree": 1,
+    "expert_parallel_degree": 12,
+    "expert_tensor_parallel_degree": 1
+  },
+  "metrics": {
+    "enable_wandb": true,
+    "log_freq": 50
+  },
+  "checkpoint": {
+    "enable": true,
+    "folder": "checkpoints",
+    "interval": 1000,
+    "async_mode": "async",
+    "enable_first_step_checkpoint": false,
+    "last_save_model_only": false,
+    "load_step": -1
+  },
+  "activation_checkpoint": {
+    "mode": "selective",
+    "selective_ac_option": "op"
+  },
+  "dataloader": {
+    "dataset": "blendcorpus",
+    "dataset_path": "torchtitan/experiments/ezpz/data-lists/aurora/nvidia-math1-code2.txt",
+    "num_workers": 2,
+    "persistent_workers": true,
+    "prefetch_factor": 2,
+    "train_iters": 1000,
+    "global_batch_size": 3072
+  },
+  "compile": {
+    "enable": true,
+    "components": [
+      "feed_forward",
+      "loss"
+    ],
+    "backend": "inductor"
+  },
+  "debug": {
+    "print_config": true
+  }
+}

--- a/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes.json
+++ b/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes.json
@@ -1,0 +1,37 @@
+{
+  "training": {
+    "local_batch_size": 1,
+    "global_batch_size": 48,
+    "seq_len": 4096,
+    "steps": 1000
+  },
+  "parallelism": {
+    "data_parallel_replicate_degree": 2,
+    "data_parallel_shard_degree": 12,
+    "tensor_parallel_degree": 1,
+    "pipeline_parallel_degree": 1,
+    "context_parallel_degree": 1,
+    "expert_parallel_degree": 12,
+    "expert_tensor_parallel_degree": 1
+  },
+  "metrics": {
+    "enable_wandb": true,
+    "log_freq": 1
+  },
+  "checkpoint": {
+    "enable": true,
+    "folder": "checkpoints",
+    "interval": 100,
+    "last_save_model_only": false,
+    "load_step": -1
+  },
+  "dataloader": {
+    "dataset": "c4_test"
+  },
+  "compile": {
+    "enable": false
+  },
+  "debug": {
+    "print_config": true
+  }
+}

--- a/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_4096_perf.json
+++ b/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_4096_perf.json
@@ -1,0 +1,55 @@
+{
+  "training": {
+    "local_batch_size": 1,
+    "global_batch_size": 24,
+    "seq_len": 4096,
+    "steps": 1000,
+    "gc_freq": 200
+  },
+  "model_spec": {
+    "model": {
+      "layer": {
+        "attention": {
+          "attn_backend": "sdpa",
+          "attn_mask_type": "causal",
+          "qk_nope_head_dim": 64,
+          "qk_rope_head_dim": 64
+        }
+      }
+    }
+  },
+  "parallelism": {
+    "data_parallel_replicate_degree": 2,
+    "data_parallel_shard_degree": 12,
+    "tensor_parallel_degree": 1,
+    "pipeline_parallel_degree": 1,
+    "context_parallel_degree": 1,
+    "expert_parallel_degree": 12,
+    "expert_tensor_parallel_degree": 1
+  },
+  "metrics": {
+    "enable_wandb": true,
+    "log_freq": 10
+  },
+  "checkpoint": {
+    "enable": true,
+    "folder": "checkpoints",
+    "interval": 200,
+    "async_mode": "async",
+    "enable_first_step_checkpoint": false,
+    "last_save_model_only": false,
+    "load_step": -1
+  },
+  "dataloader": {
+    "dataset": "blendcorpus",
+    "dataset_path": "torchtitan/experiments/ezpz/data-lists/aurora/nvidia-math1-code2.txt",
+    "train_iters": 1000,
+    "global_batch_size": 24
+  },
+  "compile": {
+    "enable": false
+  },
+  "debug": {
+    "print_config": true
+  }
+}

--- a/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_4096_prod_sim.json
+++ b/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_4096_prod_sim.json
@@ -1,0 +1,61 @@
+{
+  "training": {
+    "local_batch_size": 2,
+    "global_batch_size": 48,
+    "seq_len": 4096,
+    "steps": 1000,
+    "gc_freq": 1000
+  },
+  "model_spec": {
+    "model": {
+      "layer": {
+        "attention": {
+          "attn_backend": "sdpa",
+          "attn_mask_type": "causal",
+          "qk_nope_head_dim": 64,
+          "qk_rope_head_dim": 64
+        }
+      }
+    }
+  },
+  "parallelism": {
+    "data_parallel_replicate_degree": 2,
+    "data_parallel_shard_degree": 12,
+    "tensor_parallel_degree": 1,
+    "pipeline_parallel_degree": 1,
+    "context_parallel_degree": 1,
+    "expert_parallel_degree": 12,
+    "expert_tensor_parallel_degree": 1
+  },
+  "metrics": {
+    "enable_wandb": true,
+    "log_freq": 50
+  },
+  "checkpoint": {
+    "enable": true,
+    "folder": "checkpoints",
+    "interval": 1000,
+    "async_mode": "async",
+    "enable_first_step_checkpoint": false,
+    "last_save_model_only": false,
+    "load_step": -1
+  },
+  "activation_checkpoint": {
+    "mode": "none"
+  },
+  "dataloader": {
+    "dataset": "blendcorpus",
+    "dataset_path": "torchtitan/experiments/ezpz/data-lists/aurora/nvidia-math1-code2.txt",
+    "num_workers": 2,
+    "persistent_workers": true,
+    "prefetch_factor": 2,
+    "train_iters": 1000,
+    "global_batch_size": 48
+  },
+  "compile": {
+    "enable": false
+  },
+  "debug": {
+    "print_config": true
+  }
+}

--- a/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_4096_prod_sim_ac.json
+++ b/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_4096_prod_sim_ac.json
@@ -1,0 +1,62 @@
+{
+  "training": {
+    "local_batch_size": 2,
+    "global_batch_size": 48,
+    "seq_len": 4096,
+    "steps": 1000,
+    "gc_freq": 1000
+  },
+  "model_spec": {
+    "model": {
+      "layer": {
+        "attention": {
+          "attn_backend": "sdpa",
+          "attn_mask_type": "causal",
+          "qk_nope_head_dim": 64,
+          "qk_rope_head_dim": 64
+        }
+      }
+    }
+  },
+  "parallelism": {
+    "data_parallel_replicate_degree": 2,
+    "data_parallel_shard_degree": 12,
+    "tensor_parallel_degree": 1,
+    "pipeline_parallel_degree": 1,
+    "context_parallel_degree": 1,
+    "expert_parallel_degree": 12,
+    "expert_tensor_parallel_degree": 1
+  },
+  "metrics": {
+    "enable_wandb": true,
+    "log_freq": 50
+  },
+  "checkpoint": {
+    "enable": true,
+    "folder": "checkpoints",
+    "interval": 1000,
+    "async_mode": "async",
+    "enable_first_step_checkpoint": false,
+    "last_save_model_only": false,
+    "load_step": -1
+  },
+  "activation_checkpoint": {
+    "mode": "selective",
+    "selective_ac_option": "op"
+  },
+  "dataloader": {
+    "dataset": "blendcorpus",
+    "dataset_path": "torchtitan/experiments/ezpz/data-lists/aurora/nvidia-math1-code2.txt",
+    "num_workers": 2,
+    "persistent_workers": true,
+    "prefetch_factor": 2,
+    "train_iters": 1000,
+    "global_batch_size": 48
+  },
+  "compile": {
+    "enable": false
+  },
+  "debug": {
+    "print_config": true
+  }
+}

--- a/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_4096_prod_sim_ac_full_lb3.json
+++ b/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_4096_prod_sim_ac_full_lb3.json
@@ -1,0 +1,62 @@
+{
+  "training": {
+    "local_batch_size": 3,
+    "global_batch_size": 72,
+    "seq_len": 4096,
+    "steps": 1000,
+    "gc_freq": 1000
+  },
+  "model_spec": {
+    "model": {
+      "layer": {
+        "attention": {
+          "attn_backend": "sdpa",
+          "attn_mask_type": "causal",
+          "qk_nope_head_dim": 64,
+          "qk_rope_head_dim": 64
+        }
+      }
+    }
+  },
+  "parallelism": {
+    "data_parallel_replicate_degree": 2,
+    "data_parallel_shard_degree": 12,
+    "tensor_parallel_degree": 1,
+    "pipeline_parallel_degree": 1,
+    "context_parallel_degree": 1,
+    "expert_parallel_degree": 12,
+    "expert_tensor_parallel_degree": 1
+  },
+  "metrics": {
+    "enable_wandb": true,
+    "log_freq": 50
+  },
+  "checkpoint": {
+    "enable": true,
+    "folder": "checkpoints",
+    "interval": 1000,
+    "async_mode": "async",
+    "enable_first_step_checkpoint": false,
+    "last_save_model_only": false,
+    "load_step": -1
+  },
+  "activation_checkpoint": {
+    "mode": "full",
+    "determinism_check": "none"
+  },
+  "dataloader": {
+    "dataset": "blendcorpus",
+    "dataset_path": "torchtitan/experiments/ezpz/data-lists/aurora/nvidia-math1-code2.txt",
+    "num_workers": 2,
+    "persistent_workers": true,
+    "prefetch_factor": 2,
+    "train_iters": 1000,
+    "global_batch_size": 72
+  },
+  "compile": {
+    "enable": false
+  },
+  "debug": {
+    "print_config": true
+  }
+}

--- a/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_4096_prod_sim_ac_layer1_lb3.json
+++ b/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_4096_prod_sim_ac_layer1_lb3.json
@@ -1,0 +1,64 @@
+{
+  "training": {
+    "local_batch_size": 3,
+    "global_batch_size": 72,
+    "seq_len": 4096,
+    "steps": 1000,
+    "gc_freq": 1000
+  },
+  "model_spec": {
+    "model": {
+      "layer": {
+        "attention": {
+          "attn_backend": "sdpa",
+          "attn_mask_type": "causal",
+          "qk_nope_head_dim": 64,
+          "qk_rope_head_dim": 64
+        }
+      }
+    }
+  },
+  "parallelism": {
+    "data_parallel_replicate_degree": 2,
+    "data_parallel_shard_degree": 12,
+    "tensor_parallel_degree": 1,
+    "pipeline_parallel_degree": 1,
+    "context_parallel_degree": 1,
+    "expert_parallel_degree": 12,
+    "expert_tensor_parallel_degree": 1
+  },
+  "metrics": {
+    "enable_wandb": true,
+    "log_freq": 50
+  },
+  "checkpoint": {
+    "enable": true,
+    "folder": "checkpoints",
+    "interval": 1000,
+    "async_mode": "async",
+    "enable_first_step_checkpoint": false,
+    "last_save_model_only": false,
+    "load_step": -1
+  },
+  "activation_checkpoint": {
+    "mode": "selective",
+    "selective_ac_option": "1",
+    "determinism_check": "none",
+    "preserve_rng_state": false
+  },
+  "dataloader": {
+    "dataset": "blendcorpus",
+    "dataset_path": "torchtitan/experiments/ezpz/data-lists/aurora/nvidia-math1-code2.txt",
+    "num_workers": 2,
+    "persistent_workers": true,
+    "prefetch_factor": 2,
+    "train_iters": 1000,
+    "global_batch_size": 72
+  },
+  "compile": {
+    "enable": false
+  },
+  "debug": {
+    "print_config": true
+  }
+}

--- a/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_4096_prod_sim_ac_lb2_compile_ffn.json
+++ b/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_4096_prod_sim_ac_lb2_compile_ffn.json
@@ -1,0 +1,67 @@
+{
+  "training": {
+    "local_batch_size": 2,
+    "global_batch_size": 48,
+    "seq_len": 4096,
+    "steps": 1000,
+    "gc_freq": 1000
+  },
+  "model_spec": {
+    "model": {
+      "layer": {
+        "attention": {
+          "attn_backend": "sdpa",
+          "attn_mask_type": "causal",
+          "qk_nope_head_dim": 64,
+          "qk_rope_head_dim": 64
+        }
+      }
+    }
+  },
+  "parallelism": {
+    "data_parallel_replicate_degree": 2,
+    "data_parallel_shard_degree": 12,
+    "tensor_parallel_degree": 1,
+    "pipeline_parallel_degree": 1,
+    "context_parallel_degree": 1,
+    "expert_parallel_degree": 12,
+    "expert_tensor_parallel_degree": 1
+  },
+  "metrics": {
+    "enable_wandb": true,
+    "log_freq": 50
+  },
+  "checkpoint": {
+    "enable": true,
+    "folder": "checkpoints",
+    "interval": 1000,
+    "async_mode": "async",
+    "enable_first_step_checkpoint": false,
+    "last_save_model_only": false,
+    "load_step": -1
+  },
+  "activation_checkpoint": {
+    "mode": "selective",
+    "selective_ac_option": "op"
+  },
+  "dataloader": {
+    "dataset": "blendcorpus",
+    "dataset_path": "torchtitan/experiments/ezpz/data-lists/aurora/nvidia-math1-code2.txt",
+    "num_workers": 2,
+    "persistent_workers": true,
+    "prefetch_factor": 2,
+    "train_iters": 1000,
+    "global_batch_size": 48
+  },
+  "compile": {
+    "enable": true,
+    "components": [
+      "feed_forward",
+      "loss"
+    ],
+    "backend": "inductor"
+  },
+  "debug": {
+    "print_config": true
+  }
+}

--- a/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_4096_prod_sim_ac_lb3.json
+++ b/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_4096_prod_sim_ac_lb3.json
@@ -1,0 +1,62 @@
+{
+  "training": {
+    "local_batch_size": 3,
+    "global_batch_size": 72,
+    "seq_len": 4096,
+    "steps": 1000,
+    "gc_freq": 1000
+  },
+  "model_spec": {
+    "model": {
+      "layer": {
+        "attention": {
+          "attn_backend": "sdpa",
+          "attn_mask_type": "causal",
+          "qk_nope_head_dim": 64,
+          "qk_rope_head_dim": 64
+        }
+      }
+    }
+  },
+  "parallelism": {
+    "data_parallel_replicate_degree": 2,
+    "data_parallel_shard_degree": 12,
+    "tensor_parallel_degree": 1,
+    "pipeline_parallel_degree": 1,
+    "context_parallel_degree": 1,
+    "expert_parallel_degree": 12,
+    "expert_tensor_parallel_degree": 1
+  },
+  "metrics": {
+    "enable_wandb": true,
+    "log_freq": 50
+  },
+  "checkpoint": {
+    "enable": true,
+    "folder": "checkpoints",
+    "interval": 1000,
+    "async_mode": "async",
+    "enable_first_step_checkpoint": false,
+    "last_save_model_only": false,
+    "load_step": -1
+  },
+  "activation_checkpoint": {
+    "mode": "selective",
+    "selective_ac_option": "op"
+  },
+  "dataloader": {
+    "dataset": "blendcorpus",
+    "dataset_path": "torchtitan/experiments/ezpz/data-lists/aurora/nvidia-math1-code2.txt",
+    "num_workers": 2,
+    "persistent_workers": true,
+    "prefetch_factor": 2,
+    "train_iters": 1000,
+    "global_batch_size": 72
+  },
+  "compile": {
+    "enable": false
+  },
+  "debug": {
+    "print_config": true
+  }
+}

--- a/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_smoke.json
+++ b/torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_2nodes_smoke.json
@@ -1,0 +1,48 @@
+{
+  "training": {
+    "local_batch_size": 1,
+    "global_batch_size": 24,
+    "seq_len": 1024,
+    "steps": 40
+  },
+  "model_spec": {
+    "model": {
+      "layer": {
+        "attention": {
+          "attn_backend": "sdpa",
+          "attn_mask_type": "causal"
+        }
+      }
+    }
+  },
+  "parallelism": {
+    "data_parallel_replicate_degree": 2,
+    "data_parallel_shard_degree": 12,
+    "tensor_parallel_degree": 1,
+    "pipeline_parallel_degree": 1,
+    "context_parallel_degree": 1,
+    "expert_parallel_degree": 12,
+    "expert_tensor_parallel_degree": 1
+  },
+  "metrics": {
+    "enable_wandb": true,
+    "log_freq": 1
+  },
+  "checkpoint": {
+    "enable": true,
+    "folder": "checkpoints",
+    "interval": 5,
+    "enable_first_step_checkpoint": true,
+    "last_save_model_only": false,
+    "load_step": -1
+  },
+  "dataloader": {
+    "dataset": "c4_test"
+  },
+  "compile": {
+    "enable": false
+  },
+  "debug": {
+    "print_config": true
+  }
+}

--- a/torchtitan/experiments/ezpz/moe_runs/launch_deepseek_v3_moe_ep12.sh
+++ b/torchtitan/experiments/ezpz/moe_runs/launch_deepseek_v3_moe_ep12.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <wandb_name> [extra torchtitan args ...]"
+  exit 1
+fi
+
+WAND_NAME="$1"
+shift || true
+EXTRA_ARGS=("$@")
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Lmod scripts used by ezpz env setup can reference unset vars (e.g. ZSH_EVAL_CONTEXT),
+# so temporarily disable nounset during environment initialization.
+set +u
+source <(curl -fsSL https://bit.ly/ezpz-utils)
+ezpz_setup_env
+set -u
+
+export ZE_FLAT_DEVICE_HIERARCHY="FLAT"
+
+RUN_SLUG="$(echo "${WAND_NAME}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9._-' '-')"
+RUN_ROOT="${REPO_ROOT}/outputs/moe_runs/${RUN_SLUG}"
+CKPT_ROOT="${RUN_ROOT}/checkpoints"
+mkdir -p "${RUN_ROOT}" "${CKPT_ROOT}"
+
+export WANDB_PROJECT="${WANDB_PROJECT:-torchtitan.moe_runs}"
+export WANDB_TEAM="${WANDB_TEAM:-moe_experiments}"
+export WANDB_RUN_NAME="${WANDB_RUN_NAME:-${WAND_NAME}}"
+export WANDB_RUN_ID="${WANDB_RUN_ID:-${RUN_SLUG}}"
+export WANDB_RUN_GROUP="${WANDB_RUN_GROUP:-deepseek_v3_moe_ep12}"
+export WANDB_RESUME="${WANDB_RESUME:-allow}"
+
+export TT_CONFIG_JSON="${TT_CONFIG_JSON:-${SCRIPT_DIR}/deepseek_v3_10b2b_ep12_2nodes_smoke.json}"
+
+if [[ -z "${HF_ASSETS_PATH:-}" ]]; then
+  CANDIDATES=(
+    "${REPO_ROOT}/assets/hf/gemma-7b"
+    "${REPO_ROOT}/assets/hf/deepseek-moe-16b-base"
+    "${REPO_ROOT}/assets/hf/DeepSeek-V3.1-Base"
+  )
+  for p in "${CANDIDATES[@]}"; do
+    if [[ -d "${p}" ]]; then
+      HF_ASSETS_PATH="${p}"
+      break
+    fi
+  done
+fi
+
+if [[ -z "${HF_ASSETS_PATH:-}" || ! -d "${HF_ASSETS_PATH}" ]]; then
+  echo "No valid tokenizer/assets path found."
+  echo "Set HF_ASSETS_PATH or download tokenizer assets first, for example:"
+  echo "  python3 scripts/download_hf_assets.py --repo_id google/gemma-7b --assets tokenizer"
+  exit 1
+fi
+
+if [[ ! -f "${HF_ASSETS_PATH}/tokenizer.json" && ! -f "${HF_ASSETS_PATH}/tokenizer.model" ]]; then
+  echo "HF_ASSETS_PATH=${HF_ASSETS_PATH} does not contain tokenizer.json or tokenizer.model"
+  echo "Please point HF_ASSETS_PATH at a valid tokenizer assets directory."
+  exit 1
+fi
+export HF_ASSETS_PATH
+
+echo "Repo root: ${REPO_ROOT}"
+echo "Using TT_CONFIG_JSON=${TT_CONFIG_JSON}"
+echo "Using HF_ASSETS_PATH=${HF_ASSETS_PATH}"
+echo "Run slug: ${RUN_SLUG}"
+echo "Dump folder: ${RUN_ROOT}"
+echo "Checkpoint folder: ${CKPT_ROOT}"
+
+ezpz launch python3 -m torchtitan.experiments.ezpz.train \
+  --module deepseek_v3 \
+  --config deepseek_v3_10b_2b_ep12_from_json \
+  --dump-folder "${RUN_ROOT}" \
+  --hf-assets-path "${HF_ASSETS_PATH}" \
+  --checkpoint.enable \
+  --checkpoint.folder checkpoints \
+  --checkpoint.load_step -1 \
+  --metrics.enable_wandb \
+  --debug.print-config \
+  --debug.save-config-file "configs/effective_config.json" \
+  "${EXTRA_ARGS[@]}"

--- a/torchtitan/experiments/ezpz/moe_runs/submit_deepseek_v3_moe_ep12_128n_6h.pbs
+++ b/torchtitan/experiments/ezpz/moe_runs/submit_deepseek_v3_moe_ep12_128n_6h.pbs
@@ -1,0 +1,35 @@
+#!/bin/bash -l
+#PBS -A AuroraGPT
+#PBS -q next-eval
+#PBS -l select=128
+#PBS -l walltime=06:00:00
+#PBS -l filesystems=flare:home
+#PBS -N tt-dsv3-moe-128n
+#PBS -j oe
+
+set -euo pipefail
+
+if [[ -n "${PBS_O_WORKDIR:-}" ]]; then
+  cd "${PBS_O_WORKDIR}"
+fi
+
+REPO_ROOT="/flare/AuroraGPT/sww/tt_aurora/torchtitan"
+cd "${REPO_ROOT}"
+
+# Optional override at submit time: qsub -v RUN_NAME=my_run_name ...
+RUN_NAME="${RUN_NAME:-deepseek_v3_10b2b_ep12_128n_${PBS_JOBID%%.*}}"
+
+export TT_CONFIG_JSON="torchtitan/experiments/ezpz/moe_runs/deepseek_v3_10b2b_ep12_128nodes_4096_prod_sim_ac_lb2_compile_ffn.json"
+export HF_ASSETS_PATH="${HF_ASSETS_PATH:-${REPO_ROOT}/assets/hf/gemma-7b}"
+
+# Optional W&B overrides at submit time: qsub -v WANDB_PROJECT=...,WANDB_TEAM=...
+export WANDB_PROJECT="${WANDB_PROJECT:-torchtitan.moe_runs}"
+export WANDB_TEAM="${WANDB_TEAM:-moe_experiments}"
+export WANDB_RUN_GROUP="${WANDB_RUN_GROUP:-deepseek_v3_moe_ep12_128n}"
+
+echo "Job: ${PBS_JOBID:-no_pbs_jobid}"
+echo "Run name: ${RUN_NAME}"
+echo "TT_CONFIG_JSON: ${TT_CONFIG_JSON}"
+echo "HF_ASSETS_PATH: ${HF_ASSETS_PATH}"
+
+bash torchtitan/experiments/ezpz/moe_runs/launch_deepseek_v3_moe_ep12.sh "${RUN_NAME}"

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -4,6 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import json
+import os
+from copy import deepcopy
+from dataclasses import is_dataclass
+from typing import Any
+
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
@@ -18,11 +24,73 @@ from torchtitan.config import (
     ParallelismConfig,
     TrainingConfig,
 )
+from torchtitan.experiments.ezpz.blendcorpus.blendcorpus_builder import (
+    BlendCorpusDataLoader,
+)
 from torchtitan.hf_datasets.text_datasets import HuggingFaceTextDataLoader
 from torchtitan.protocols.model_converter import ModelConvertersContainer
 from torchtitan.trainer import Trainer
 
 from . import model_registry
+
+TT_CONFIG_JSON_ENV = "TT_CONFIG_JSON"
+
+
+def _load_json_overrides() -> dict[str, Any]:
+    path = os.environ.get(TT_CONFIG_JSON_ENV, "").strip()
+    if not path:
+        raise ValueError(
+            f"{TT_CONFIG_JSON_ENV} must point to a JSON file when using *_from_json configs."
+        )
+
+    with open(path, encoding="utf-8") as f:
+        overrides = json.load(f)
+
+    if not isinstance(overrides, dict):
+        raise ValueError(
+            f"Expected top-level JSON object in {path!r}, got {type(overrides).__name__}."
+        )
+
+    return overrides
+
+
+def _apply_config_overrides(
+    target: Any,
+    overrides: dict[str, Any],
+    path: str = "",
+) -> None:
+    for key, value in overrides.items():
+        if not hasattr(target, key):
+            raise KeyError(f"Unknown config field {key!r} at path {path or '<root>'}.")
+
+        current_value = getattr(target, key)
+        field_path = f"{path}.{key}" if path else key
+
+        if isinstance(value, dict):
+            if not is_dataclass(current_value):
+                raise TypeError(
+                    f"Expected dataclass at {field_path!r} for nested override, "
+                    f"got {type(current_value).__name__}."
+                )
+            _apply_config_overrides(current_value, value, field_path)
+            continue
+
+        setattr(target, key, value)
+
+
+def _deepseek_v3_10b_2b_model_spec():
+    # Start from the existing 16B architecture and downscale experts / top-k to
+    # target an approximately 10B total / 2B active MoE regime.
+    model_spec = deepcopy(model_registry("16B"))
+    model_spec.flavor = "10B_2B_EP12"
+    model_cfg = model_spec.model
+
+    assert model_cfg.layer.moe is not None
+    model_cfg.layer.n_dense_layers = 1
+    model_cfg.layer.moe.num_experts = 36
+    model_cfg.layer.moe.top_k = 3
+    model_cfg.layer.moe.num_shared_experts = 2
+    return model_spec
 
 
 def deepseek_v3_debugmodel() -> Trainer.Config:
@@ -133,3 +201,53 @@ def deepseek_v3_671b() -> Trainer.Config:
             ],
         ),
     )
+
+
+def deepseek_v3_10b_2b_ep12() -> Trainer.Config:
+    return Trainer.Config(
+        hf_assets_path="./assets/hf/gemma-7b",
+        metrics=MetricsProcessor.Config(log_freq=1, enable_wandb=True),
+        model_spec=_deepseek_v3_10b_2b_model_spec(),
+        dataloader=BlendCorpusDataLoader.Config(dataset="c4_test"),
+        optimizer=OptimizersContainer.Config(lr=2.2e-4),
+        lr_scheduler=LRSchedulersContainer.Config(
+            warmup_steps=200,
+            decay_ratio=0.8,
+            decay_type="cosine",
+            min_lr_factor=0.1,
+        ),
+        training=TrainingConfig(
+            local_batch_size=1,
+            global_batch_size=48,
+            seq_len=4096,
+            steps=1000,
+        ),
+        parallelism=ParallelismConfig(
+            data_parallel_replicate_degree=2,
+            data_parallel_shard_degree=12,
+            tensor_parallel_degree=1,
+            pipeline_parallel_degree=1,
+            context_parallel_degree=1,
+            expert_parallel_degree=12,
+            expert_tensor_parallel_degree=1,
+            pipeline_parallel_schedule="1F1B",
+        ),
+        checkpoint=CheckpointManager.Config(
+            enable=True,
+            folder="checkpoints",
+            interval=100,
+            last_save_model_only=False,
+            load_step=-1,
+        ),
+        activation_checkpoint=ActivationCheckpointConfig(
+            mode="selective",
+            selective_ac_option="op",
+        ),
+        compile=CompileConfig(enable=False, components=["loss"]),
+    )
+
+
+def deepseek_v3_10b_2b_ep12_from_json() -> Trainer.Config:
+    cfg = deepseek_v3_10b_2b_ep12()
+    _apply_config_overrides(cfg, _load_json_overrides())
+    return cfg

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
+import os
+import json
 from dataclasses import dataclass
 from typing import cast
 
@@ -25,6 +27,35 @@ from torchtitan.models.common.rope import apply_rotary_emb_single_complex
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import has_cuda_capability
+
+
+def _infer_vocab_size_from_tokenizer_assets(hf_assets_path: str) -> int | None:
+    tokenizer_json_path = os.path.join(hf_assets_path, "tokenizer.json")
+    if not os.path.exists(tokenizer_json_path):
+        return None
+
+    with open(tokenizer_json_path, encoding="utf-8") as f:
+        tokenizer_data = json.load(f)
+
+    vocab = tokenizer_data.get("model", {}).get("vocab", {})
+    added_tokens = tokenizer_data.get("added_tokens", [])
+
+    max_token_id = -1
+    if isinstance(vocab, dict):
+        for token_id in vocab.values():
+            if isinstance(token_id, int):
+                max_token_id = max(max_token_id, token_id)
+
+    if isinstance(added_tokens, list):
+        for token_info in added_tokens:
+            if isinstance(token_info, dict):
+                token_id = token_info.get("id")
+                if isinstance(token_id, int):
+                    max_token_id = max(max_token_id, token_id)
+
+    if max_token_id < 0:
+        return None
+    return max_token_id + 1
 
 
 class Attention(BaseAttention):
@@ -246,6 +277,17 @@ class DeepSeekV3Model(Decoder):
             training = trainer_config.training
             parallelism = trainer_config.parallelism
             debug = trainer_config.debug
+            inferred_vocab_size = _infer_vocab_size_from_tokenizer_assets(
+                trainer_config.hf_assets_path
+            )
+            if inferred_vocab_size is not None and inferred_vocab_size != self.vocab_size:
+                logger.info(
+                    f"Overriding model vocab_size from {self.vocab_size} to "
+                    f"{inferred_vocab_size} based on tokenizer assets at "
+                    f"{trainer_config.hf_assets_path}."
+                )
+                self.vocab_size = inferred_vocab_size
+
             seq_len = training.seq_len
             if seq_len > self.rope.max_seq_len:
                 logger.warning(

--- a/torchtitan/models/deepseek_v3/parallelize.py
+++ b/torchtitan/models/deepseek_v3/parallelize.py
@@ -6,6 +6,7 @@
 
 import torch
 import torch.nn as nn
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import CheckpointWrapper
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import Replicate, Shard
 from torch.distributed.tensor.parallel import (
@@ -56,6 +57,60 @@ _op_sac_save_list = {
     torch._higher_order_ops.flex_attention,
     torch._higher_order_ops.inductor_compiled_code,
 }
+
+
+def apply_compile_feed_forward_only(
+    model: DeepSeekV3Model, compile_config: CompileConfig
+) -> None:
+    """Compile feed-forward modules while leaving attention in eager mode.
+
+    This compiles:
+    - dense `feed_forward` blocks (for non-MoE transformer blocks)
+    - MoE `shared_experts` feed-forward blocks (when present)
+
+    It intentionally does not compile token-routing / expert-dispatch paths.
+    """
+    dense_ffn_count = 0
+    shared_ffn_count = 0
+
+    # pyrefly: ignore [missing-attribute]
+    for layer_id, transformer_block in model.layers.named_children():
+        block = (
+            transformer_block._checkpoint_wrapped_module
+            if isinstance(transformer_block, CheckpointWrapper)
+            else transformer_block
+        )
+
+        # pyrefly: ignore [missing-attribute]
+        if block.moe_enabled:
+            # pyrefly: ignore [missing-attribute]
+            shared_experts = block.moe.shared_experts
+            if shared_experts is not None:
+                # pyrefly: ignore [missing-attribute]
+                block.moe.shared_experts = torch.compile(
+                    shared_experts,
+                    backend=compile_config.backend,
+                    fullgraph=True,
+                )
+                shared_ffn_count += 1
+        else:
+            # pyrefly: ignore [missing-attribute]
+            block.feed_forward = torch.compile(
+                # pyrefly: ignore [missing-attribute]
+                block.feed_forward,
+                backend=compile_config.backend,
+                fullgraph=True,
+            )
+            dense_ffn_count += 1
+
+        # keep this assignment pattern consistent with other compile paths
+        # pyrefly: ignore [missing-attribute]
+        model.layers.register_module(layer_id, transformer_block)
+
+    logger.info(
+        "Compiling feed-forward modules only with torch.compile "
+        f"(dense_ffn={dense_ffn_count}, shared_ffn={shared_ffn_count})"
+    )
 
 
 # Adapted from llama4/infra/parallelize.py
@@ -163,6 +218,9 @@ def parallelize_deepseekv3(
     model_compile_enabled = (
         compile_config.enable and "model" in compile_config.components
     )
+    feed_forward_compile_enabled = (
+        compile_config.enable and "feed_forward" in compile_config.components
+    )
 
     if ac_config.mode != "none":
         apply_ac(
@@ -176,6 +234,8 @@ def parallelize_deepseekv3(
 
     if model_compile_enabled:
         apply_compile(model, compile_config, parallel_dims.ep_enabled)
+    elif feed_forward_compile_enabled:
+        apply_compile_feed_forward_only(model, compile_config)
 
     dp_mesh: DeviceMesh | None = None
     if parallel_dims.fsdp_enabled or parallel_dims.ep_enabled:

--- a/torchtitan/models/llama3/parallelize.py
+++ b/torchtitan/models/llama3/parallelize.py
@@ -9,7 +9,6 @@
 
 import torch
 import torch.nn as nn
-from torch.distributed._composable.fsdp import FSDPModule
 from torch.distributed._composable.replicate import replicate
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard, MixedPrecisionPolicy
@@ -294,9 +293,31 @@ def disable_fsdp_gradient_division(model: nn.Module) -> None:
     Args:
         model: The model containing FSDP-wrapped modules
     """
+    force_sum_reduction = False
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        backend = str(torch.distributed.get_backend()).lower()
+        if "nccl" not in backend:
+            force_sum_reduction = True
+
+    fsdp_modules_updated = 0
     for module in model.modules():
-        if isinstance(module, FSDPModule):
-            module.set_gradient_divide_factor(1.0)
+        # Be resilient to FSDPModule class location changes across PyTorch releases.
+        set_divide_factor = getattr(module, "set_gradient_divide_factor", None)
+        if callable(set_divide_factor):
+            set_divide_factor(1.0)
+            fsdp_modules_updated += 1
+            if force_sum_reduction:
+                set_force_sum = getattr(
+                    module, "set_force_sum_reduction_for_comms", None
+                )
+                if callable(set_force_sum):
+                    set_force_sum(True)
+
+    logger.info(
+        "Configured FSDP gradient division for %d modules (force_sum_reduction=%s)",
+        fsdp_modules_updated,
+        force_sum_reduction,
+    )
 
 
 def apply_fsdp(

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -242,6 +242,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             tokenizer=self.tokenizer,
             seq_len=config.training.seq_len,
             local_batch_size=config.training.local_batch_size,
+            global_batch_size=config.training.global_batch_size,
+            training_steps=config.training.steps,
+            parallel_dims=parallel_dims,
         )
 
         # build model (using meta init)


### PR DESCRIPTION
This pull request introduces a framework for launching DeepSeek V3-style Mixture-of-Experts (MoE) training runs, with a focus on flexible, large-scale configuration via JSON files and environment variables. It adds a new set of configuration files and documentation for various MoE training scenarios, and enhances the configuration registry to support overlaying JSON-based overrides onto base configs. Additionally, it improves robustness in the FSDP gradient division logic to better handle PyTorch version differences.

The most important changes are:

**1. MoE Run Configuration and Documentation**
- Added a new directory (`moe_runs`) containing multiple JSON configuration files for different DeepSeek V3 MoE training scenarios (e.g., 2 nodes, 128 nodes, various batch sizes, activation checkpointing strategies, and compilation options). This enables easy experimentation with different distributed and model configurations. [[1]](diffhunk://#diff-5a61bb136d39ccb94fa56a4cd565a07d0f2421c739dd48b4ee24047a76dc08bdR1-R37) [[2]](diffhunk://#diff-b8b4b84d9199289f6e9c394d8a2b7a4ba7530aeea5867a3d0e11f3ac716a9addR1-R55) [[3]](diffhunk://#diff-c694aa4152a34b799e03753ed6be7c2419afeac2b17d63c307ddf907d0a6adc2R1-R61) [[4]](diffhunk://#diff-5a91df0cad3dce2e9fc1b91226b5a233b4aa30d16db3c575922c1faf78ed43cdR1-R62) [[5]](diffhunk://#diff-1daf514154ba488b0e949be1118331945c7799764dea872c50be81fc5e78e851R1-R62) [[6]](diffhunk://#diff-9555703d5047002bbaba4c41ee2f1c29a058fb274e4757ab0c1e8fe944198e1aR1-R64) [[7]](diffhunk://#diff-96709ac3873570dba1483ba6d595bbbc7eb8f09366d8c92f2fee6acb98fe6725R1-R67) [[8]](diffhunk://#diff-25f75c10e410b512333a6cb45badddc651b8d7486e2ffa43d24a586c83dc7f94R1-R62) [[9]](diffhunk://#diff-30d1e3b993accc005bc34a3ba0263ecab0a12036b827c982e146c21c59148042R1-R67)
- Added a comprehensive README (`moe_runs/README.md`) explaining how to launch these MoE runs, customize configs, and use the new setup.

**2. JSON-Based Config Overrides**
- Enhanced the `config_registry.py` to support loading configuration overrides from a JSON file specified via the `TT_CONFIG_JSON` environment variable, and overlaying these onto base configs. This allows dynamic, environment-driven configuration without code changes. [[1]](diffhunk://#diff-516224eb10bbb2d9d6e99f3fc07a05be90f831b01db2bdd7d461dcc242060320R1-R5) [[2]](diffhunk://#diff-516224eb10bbb2d9d6e99f3fc07a05be90f831b01db2bdd7d461dcc242060320R21-R22) [[3]](diffhunk://#diff-516224eb10bbb2d9d6e99f3fc07a05be90f831b01db2bdd7d461dcc242060320R57-R104) [[4]](diffhunk://#diff-516224eb10bbb2d9d6e99f3fc07a05be90f831b01db2bdd7d461dcc242060320R121-R136)

**3. Improved FSDP Gradient Division Handling**
- Updated the FSDP gradient division logic in `parallelize.py` to be more robust against PyTorch version changes by dynamically checking for the presence of relevant methods, rather than relying on specific class imports or locations. This increases compatibility and maintainability. [[1]](diffhunk://#diff-920940fece1ce3cb0dac7620a167b2c686e1a71635c4a46379482081f0070b71L5) [[2]](diffhunk://#diff-920940fece1ce3cb0dac7620a167b2c686e1a71635c4a46379482081f0070b71L232-R253)

**4. Example/Test Configs**
- Added example/test JSON config files (e.g., `ezpz_test.json`) to demonstrate or validate the new configuration override mechanism.

These changes collectively make it easier to configure, launch, and experiment with large-scale MoE training runs on different hardware setups, while improving the maintainability and flexibility of the codebase.

## Summary by Sourcery

Introduce ezpz-based DeepSeek V3 MoE run presets with JSON-driven configuration overrides and more robust runtime behaviors for compilation, vocab sizing, and FSDP gradient handling.

New Features:
- Add DeepSeek V3 10B/2B EP12 trainer config and ezpz launcher scripts/JSON presets for MoE runs across different node and batch configurations.
- Support JSON-configured ezpz AGPT and DeepSeek V3 configs via TT_CONFIG_JSON, enabling environment-driven overrides of base trainer configs.
- Automatically infer and override DeepSeek V3 model vocab size from Hugging Face tokenizer assets when available.
- Enable selective compilation of only feed-forward modules in DeepSeek V3 models via a dedicated compile component flag.

Bug Fixes:
- Make FSDP gradient division configuration resilient to PyTorch FSDP API and backend variations in both LLaMA 3 and ezpz AGPT paths.

Enhancements:
- Extend Trainer dataloader construction with global batch size, training steps, and parallelism metadata.
- Add a downscaled DeepSeek V3 10B/2B EP12 MoE model spec derived from the existing 16B architecture for ezpz experiments.

Documentation:
- Add README documenting DeepSeek V3 MoE ezpz runs, launcher usage, tokenizer asset setup, and JSON override workflows.

Tests:
- Add example JSON configs (including ezpz_test.json and multiple MoE run variants) to validate and illustrate the JSON override mechanism and MoE run presets.

Chores:
- Add PBS submission script for DeepSeek V3 MoE 128-node ezpz runs.