### PR TITLE
Fix MoE expert FSDP mesh info for HSDP

### DIFF
--- a/torchtitan/experiments/ezpz/moe/parallelize.py
+++ b/torchtitan/experiments/ezpz/moe/parallelize.py
@@ -320,12 +320,51 @@ def apply_fsdp(
                 # PyTorch API path that may not exist in older releases.
                 from torch.distributed.fsdp._fully_shard._fsdp_common import (
                     FSDPMeshInfo,
+                    HSDPMeshInfo,
                     ShardPlacementResult,
                 )
 
+                def _mesh_dim(mesh: DeviceMesh, dim_name: str) -> int:
+                    mesh_dim_names = mesh.mesh_dim_names
+                    if mesh_dim_names is None:
+                        if mesh.ndim == 1:
+                            return 0
+                        raise ValueError(
+                            f"Mesh {mesh} must have dim names for 2D HSDP."
+                        )
+                    try:
+                        return tuple(mesh_dim_names).index(dim_name)
+                    except ValueError:
+                        raise ValueError(
+                            f"Mesh {mesh} does not contain dim {dim_name!r}; "
+                            f"names={mesh_dim_names!r}"
+                        ) from None
+
+                def _dp_mesh_info(
+                    mesh: DeviceMesh,
+                    *,
+                    shard_dim_name: str,
+                ) -> FSDPMeshInfo:
+                    if mesh.ndim == 1:
+                        return FSDPMeshInfo(
+                            mesh=mesh,
+                            shard_mesh_dim=_mesh_dim(mesh, shard_dim_name),
+                        )
+                    if mesh.ndim == 2:
+                        return HSDPMeshInfo(
+                            mesh=mesh,
+                            shard_mesh_dim=_mesh_dim(mesh, shard_dim_name),
+                            replicate_mesh_dim=_mesh_dim(mesh, "dp_replicate"),
+                        )
+                    raise ValueError(f"Expected 1D/2D FSDP mesh, got {mesh}")
+
                 assert edp_mesh is not None
-                edp_mesh_info = FSDPMeshInfo(mesh=edp_mesh, shard_mesh_dim=0)
-                dp_mesh_info = FSDPMeshInfo(mesh=dp_mesh, shard_mesh_dim=0)
+                # Match fully_shard()'s normal 2D behavior: 2D meshes must use
+                # HSDPMeshInfo so DTensor placements include both replicate and
+                # shard axes. Returning FSDPMeshInfo for a 2D mesh creates specs
+                # like a 2D DeviceMesh with only one placement.
+                edp_mesh_info = _dp_mesh_info(edp_mesh, shard_dim_name="efsdp")
+                dp_mesh_info = _dp_mesh_info(dp_mesh, shard_dim_name="fsdp")
 
                 def _shard_placement_fn(
                     param: nn.Parameter,

--- a/torchtitan/experiments/ezpz/moe/parallelize.py
+++ b/torchtitan/experiments/ezpz/moe/parallelize.py
@@ -340,11 +340,12 @@ def apply_fsdp(
                             f"names={mesh_dim_names!r}"
                         ) from None
 
-                def _dp_mesh_info(
+                def _fsdp_mesh_info(
                     mesh: DeviceMesh,
                     *,
                     shard_dim_name: str,
-                ) -> FSDPMeshInfo:
+                ) -> FSDPMeshInfo | HSDPMeshInfo:
+                    """Build the correct FSDP mesh metadata for 1D or 2D meshes."""
                     if mesh.ndim == 1:
                         return FSDPMeshInfo(
                             mesh=mesh,
@@ -363,15 +364,15 @@ def apply_fsdp(
                 # HSDPMeshInfo so DTensor placements include both replicate and
                 # shard axes. Returning FSDPMeshInfo for a 2D mesh creates specs
                 # like a 2D DeviceMesh with only one placement.
-                edp_mesh_info = _dp_mesh_info(edp_mesh, shard_dim_name="efsdp")
-                dp_mesh_info = _dp_mesh_info(dp_mesh, shard_dim_name="fsdp")
+                edp_mesh_info = _fsdp_mesh_info(edp_mesh, shard_dim_name="efsdp")
+                dp_mesh_info = _fsdp_mesh_info(dp_mesh, shard_dim_name="fsdp")
 
                 def _shard_placement_fn(
                     param: nn.Parameter,
                     _expert_params: set = expert_params,
                     _expert_placement: Shard = expert_shard_placement,
-                    _edp_mesh_info: FSDPMeshInfo = edp_mesh_info,
-                    _dp_mesh_info: FSDPMeshInfo = dp_mesh_info,
+                    _edp_mesh_info: FSDPMeshInfo | HSDPMeshInfo = edp_mesh_info,
+                    _dp_mesh_info: FSDPMeshInfo | HSDPMeshInfo = dp_mesh_info,
                 ) -> ShardPlacementResult:
                     if param in _expert_params:
                         return ShardPlacementResult(


### PR DESCRIPTION
## Summary

Fixes the custom MoE expert FSDP sharding path for HSDP meshes.

The previous code constructed `FSDPMeshInfo` for both 1D and 2D meshes. For 2D HSDP meshes, this can produce DTensor specs whose mesh has both replicate and shard dimensions but whose placements only describe one axis.

This changes the custom placement path to use `HSDPMeshInfo` for 2D meshes and preserves `FSDPMeshInfo` for 1D meshes.

## Validation

- `git diff --cached --check`
- `.venv/bin/python -m py_compile torchtitan/experiments/ezpz/moe/parallelize.py`
- Validated in Aurora EP/HSDP MoE runs while debugging EP setup.

## Summary by Sourcery

Bug Fixes:
- Ensure 2D HSDP meshes use HSDPMeshInfo so DTensor placements include both shard and replicate axes instead of an incomplete single-axis spec.