### PR TITLE
Add padded batched matmul MoE expert backend

### DIFF
--- a/tests/unit_tests/test_moe_expert_backends.py
+++ b/tests/unit_tests/test_moe_expert_backends.py
@@ -21,27 +21,57 @@ def _init_weights(
     num_experts: int,
     dim: int,
     hidden_dim: int,
+    *,
+    device: torch.device | str = "cpu",
     dtype: torch.dtype = torch.float32,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    w1 = torch.randn(num_experts, hidden_dim, dim, dtype=dtype) * 0.02
-    w2 = torch.randn(num_experts, dim, hidden_dim, dtype=dtype) * 0.02
-    w3 = torch.randn(num_experts, hidden_dim, dim, dtype=dtype) * 0.02
+    w1 = (
+        torch.randn(num_experts, hidden_dim, dim, device=device, dtype=dtype) * 0.02
+    )
+    w2 = (
+        torch.randn(num_experts, dim, hidden_dim, device=device, dtype=dtype) * 0.02
+    )
+    w3 = (
+        torch.randn(num_experts, hidden_dim, dim, device=device, dtype=dtype) * 0.02
+    )
     return w1, w2, w3
 
 
+def _test_configs() -> list[tuple[str, torch.dtype, float, float]]:
+    configs = [("cpu", torch.float32, 1e-5, 1e-5)]
+    if torch.cuda.is_available():
+        configs.append(("cuda", torch.float32, 1e-5, 1e-5))
+        configs.append(("cuda", torch.float16, 5e-3, 5e-3))
+    return configs
+
+
 class MoEExpertBackendsTest(unittest.TestCase):
-    def test_batched_mm_padded_matches_for_loop_kernel(self) -> None:
-        torch.manual_seed(1234)
-        num_experts = 6
-        dim = 16
-        hidden_dim = 24
-        counts = torch.tensor([0, 3, 5, 1, 0, 7], dtype=torch.int64)
+    def _assert_batched_mm_matches_for_loop(
+        self,
+        counts: torch.Tensor,
+        *,
+        dim: int,
+        hidden_dim: int,
+        device: str,
+        dtype: torch.dtype,
+        rtol: float,
+        atol: float,
+    ) -> None:
+        num_experts = counts.numel()
         total_tokens = int(counts.sum().item())
 
-        w1, w2, w3 = _init_weights(num_experts, dim, hidden_dim)
-        x = torch.randn(total_tokens, dim)
+        w1, w2, w3 = _init_weights(
+            num_experts,
+            dim,
+            hidden_dim,
+            device=device,
+            dtype=dtype,
+        )
+        x = torch.randn(total_tokens, dim, device=device, dtype=dtype)
 
-        ref_inputs = [t.detach().clone().requires_grad_(True) for t in (w1, w2, w3, x)]
+        ref_inputs = [
+            t.detach().clone().requires_grad_(True) for t in (w1, w2, w3, x)
+        ]
         test_inputs = [
             t.detach().clone().requires_grad_(True) for t in (w1, w2, w3, x)
         ]
@@ -50,68 +80,116 @@ class MoEExpertBackendsTest(unittest.TestCase):
         test_out = _run_experts_batched_mm_padded(
             *test_inputs[:3], test_inputs[3], counts
         )
-        assert_close(test_out, ref_out, rtol=1e-5, atol=1e-5)
+        assert_close(test_out, ref_out, rtol=rtol, atol=atol)
 
-        grad = torch.randn_like(ref_out)
+        grad = (
+            torch.randn_like(ref_out) if ref_out.numel() else torch.empty_like(ref_out)
+        )
         ref_out.backward(grad)
         test_out.backward(grad)
 
         for ref, test in zip(ref_inputs, test_inputs):
-            assert_close(test.grad, ref.grad, rtol=1e-5, atol=1e-5)
+            assert_close(test.grad, ref.grad, rtol=rtol, atol=atol)
+
+    def test_batched_mm_padded_matches_for_loop_kernel(self) -> None:
+        dim = 16
+        hidden_dim = 24
+        for device, dtype, rtol, atol in _test_configs():
+            cases = {
+                "mixed_counts": torch.tensor(
+                    [0, 3, 5, 1, 0, 7], device=device, dtype=torch.int64
+                ),
+                "empty_counts": torch.empty(0, device=device, dtype=torch.int64),
+                "all_zero_counts": torch.tensor(
+                    [0, 0, 0], device=device, dtype=torch.int64
+                ),
+            }
+            for case_name, counts in cases.items():
+                with self.subTest(case=case_name, device=device, dtype=dtype):
+                    torch.manual_seed(1234)
+                    self._assert_batched_mm_matches_for_loop(
+                        counts,
+                        dim=dim,
+                        hidden_dim=hidden_dim,
+                        device=device,
+                        dtype=dtype,
+                        rtol=rtol,
+                        atol=atol,
+                    )
 
     def test_grouped_experts_backend_selector_matches_for_loop(self) -> None:
-        torch.manual_seed(5678)
-        num_experts = 4
-        dim = 12
-        hidden_dim = 20
-        top_k = 2
-        counts = torch.tensor([4, 0, 3, 2], dtype=torch.int64)
-        total_tokens = int(counts.sum().item())
+        for device, dtype, rtol, atol in _test_configs():
+            with self.subTest(device=device, dtype=dtype):
+                torch.manual_seed(5678)
+                num_experts = 4
+                dim = 12
+                hidden_dim = 20
+                top_k = 2
+                counts = torch.tensor(
+                    [4, 0, 3, 2], device=device, dtype=torch.int64
+                )
+                total_tokens = int(counts.sum().item())
 
-        base_cfg = dict(
-            dim=dim,
-            hidden_dim=hidden_dim,
-            num_experts=num_experts,
-            token_dispatcher=LocalTokenDispatcher.Config(
-                num_experts=num_experts,
-                top_k=top_k,
-                score_before_experts=True,
-            ),
-        )
-        ref = GroupedExperts.Config(
-            **base_cfg,
-            use_grouped_mm=False,
-            compute_backend="for_loop",
-        ).build()
-        test = GroupedExperts.Config(
-            **base_cfg,
-            use_grouped_mm=False,
-            compute_backend="batched_mm_padded",
-        ).build()
+                base_cfg = dict(
+                    dim=dim,
+                    hidden_dim=hidden_dim,
+                    num_experts=num_experts,
+                    token_dispatcher=LocalTokenDispatcher.Config(
+                        num_experts=num_experts,
+                        top_k=top_k,
+                        score_before_experts=True,
+                    ),
+                )
+                ref = GroupedExperts.Config(
+                    **base_cfg,
+                    use_grouped_mm=False,
+                    compute_backend="for_loop",
+                ).build()
+                test = GroupedExperts.Config(
+                    **base_cfg,
+                    use_grouped_mm=False,
+                    compute_backend="batched_mm_padded",
+                ).build()
+                ref.to(device=device, dtype=dtype)
+                test.to(device=device, dtype=dtype)
 
-        w1, w2, w3 = _init_weights(num_experts, dim, hidden_dim)
-        with torch.no_grad():
-            ref.w1.copy_(w1)
-            ref.w2.copy_(w2)
-            ref.w3.copy_(w3)
-            test.w1.copy_(w1)
-            test.w2.copy_(w2)
-            test.w3.copy_(w3)
+                w1, w2, w3 = _init_weights(
+                    num_experts,
+                    dim,
+                    hidden_dim,
+                    device=device,
+                    dtype=dtype,
+                )
+                with torch.no_grad():
+                    ref.w1.copy_(w1)
+                    ref.w2.copy_(w2)
+                    ref.w3.copy_(w3)
+                    test.w1.copy_(w1)
+                    test.w2.copy_(w2)
+                    test.w3.copy_(w3)
 
-        x = torch.randn(total_tokens, dim, requires_grad=True)
-        x_test = x.detach().clone().requires_grad_(True)
+                x = torch.randn(
+                    total_tokens,
+                    dim,
+                    device=device,
+                    dtype=dtype,
+                    requires_grad=True,
+                )
+                x_test = x.detach().clone().requires_grad_(True)
 
-        ref_out = ref._experts_forward(x, counts)
-        test_out = test._experts_forward(x_test, counts)
-        assert_close(test_out, ref_out, rtol=1e-5, atol=1e-5)
+                ref_out = ref._experts_forward(x, counts)
+                test_out = test._experts_forward(x_test, counts)
+                assert_close(test_out, ref_out, rtol=rtol, atol=atol)
 
-        grad = torch.randn_like(ref_out)
-        ref_out.backward(grad)
-        test_out.backward(grad)
+                grad = torch.randn_like(ref_out)
+                ref_out.backward(grad)
+                test_out.backward(grad)
 
-        assert_close(x_test.grad, x.grad, rtol=1e-5, atol=1e-5)
-        for ref_param, test_param in zip(ref.parameters(), test.parameters()):
-            assert_close(test_param.grad, ref_param.grad, rtol=1e-5, atol=1e-5)
+                assert_close(x_test.grad, x.grad, rtol=rtol, atol=atol)
+                for ref_param, test_param in zip(ref.parameters(), test.parameters()):
+                    assert_close(
+                        test_param.grad, ref_param.grad, rtol=rtol, atol=atol
+                    )
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_moe_expert_backends.py
+++ b/tests/unit_tests/test_moe_expert_backends.py
@@ -1,0 +1,118 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from torch.testing import assert_close
+
+from torchtitan.models.common.moe import (
+    GroupedExperts,
+    _run_experts_batched_mm_padded,
+    _run_experts_for_loop,
+)
+from torchtitan.models.common.token_dispatcher import LocalTokenDispatcher
+
+
+def _init_weights(
+    num_experts: int,
+    dim: int,
+    hidden_dim: int,
+    dtype: torch.dtype = torch.float32,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    w1 = torch.randn(num_experts, hidden_dim, dim, dtype=dtype) * 0.02
+    w2 = torch.randn(num_experts, dim, hidden_dim, dtype=dtype) * 0.02
+    w3 = torch.randn(num_experts, hidden_dim, dim, dtype=dtype) * 0.02
+    return w1, w2, w3
+
+
+class MoEExpertBackendsTest(unittest.TestCase):
+    def test_batched_mm_padded_matches_for_loop_kernel(self) -> None:
+        torch.manual_seed(1234)
+        num_experts = 6
+        dim = 16
+        hidden_dim = 24
+        counts = torch.tensor([0, 3, 5, 1, 0, 7], dtype=torch.int64)
+        total_tokens = int(counts.sum().item())
+
+        w1, w2, w3 = _init_weights(num_experts, dim, hidden_dim)
+        x = torch.randn(total_tokens, dim)
+
+        ref_inputs = [t.detach().clone().requires_grad_(True) for t in (w1, w2, w3, x)]
+        test_inputs = [
+            t.detach().clone().requires_grad_(True) for t in (w1, w2, w3, x)
+        ]
+
+        ref_out = _run_experts_for_loop(*ref_inputs[:3], ref_inputs[3], counts)
+        test_out = _run_experts_batched_mm_padded(
+            *test_inputs[:3], test_inputs[3], counts
+        )
+        assert_close(test_out, ref_out, rtol=1e-5, atol=1e-5)
+
+        grad = torch.randn_like(ref_out)
+        ref_out.backward(grad)
+        test_out.backward(grad)
+
+        for ref, test in zip(ref_inputs, test_inputs):
+            assert_close(test.grad, ref.grad, rtol=1e-5, atol=1e-5)
+
+    def test_grouped_experts_backend_selector_matches_for_loop(self) -> None:
+        torch.manual_seed(5678)
+        num_experts = 4
+        dim = 12
+        hidden_dim = 20
+        top_k = 2
+        counts = torch.tensor([4, 0, 3, 2], dtype=torch.int64)
+        total_tokens = int(counts.sum().item())
+
+        base_cfg = dict(
+            dim=dim,
+            hidden_dim=hidden_dim,
+            num_experts=num_experts,
+            token_dispatcher=LocalTokenDispatcher.Config(
+                num_experts=num_experts,
+                top_k=top_k,
+                score_before_experts=True,
+            ),
+        )
+        ref = GroupedExperts.Config(
+            **base_cfg,
+            use_grouped_mm=False,
+            compute_backend="for_loop",
+        ).build()
+        test = GroupedExperts.Config(
+            **base_cfg,
+            use_grouped_mm=False,
+            compute_backend="batched_mm_padded",
+        ).build()
+
+        w1, w2, w3 = _init_weights(num_experts, dim, hidden_dim)
+        with torch.no_grad():
+            ref.w1.copy_(w1)
+            ref.w2.copy_(w2)
+            ref.w3.copy_(w3)
+            test.w1.copy_(w1)
+            test.w2.copy_(w2)
+            test.w3.copy_(w3)
+
+        x = torch.randn(total_tokens, dim, requires_grad=True)
+        x_test = x.detach().clone().requires_grad_(True)
+
+        ref_out = ref._experts_forward(x, counts)
+        test_out = test._experts_forward(x_test, counts)
+        assert_close(test_out, ref_out, rtol=1e-5, atol=1e-5)
+
+        grad = torch.randn_like(ref_out)
+        ref_out.backward(grad)
+        test_out.backward(grad)
+
+        assert_close(x_test.grad, x.grad, rtol=1e-5, atol=1e-5)
+        for ref_param, test_param in zip(ref.parameters(), test.parameters()):
+            assert_close(test_param.grad, ref_param.grad, rtol=1e-5, atol=1e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/experiments/ezpz/moe/__init__.py
+++ b/torchtitan/experiments/ezpz/moe/__init__.py
@@ -945,7 +945,6 @@ def _10b_2b_sdpa_batched_mm_padded() -> moeModel.Config:
         if layer_cfg.moe is None:
             continue
         layer_cfg.moe.experts.compute_backend = "batched_mm_padded"
-        layer_cfg.moe.experts.use_grouped_mm = False
     return cfg
 
 

--- a/torchtitan/experiments/ezpz/moe/__init__.py
+++ b/torchtitan/experiments/ezpz/moe/__init__.py
@@ -938,6 +938,17 @@ def _10b_2b_sdpa() -> moeModel.Config:
     return cfg
 
 
+def _10b_2b_sdpa_batched_mm_padded() -> moeModel.Config:
+    """10B_2B SDPA with padded torch.bmm expert computation."""
+    cfg = _10b_2b_sdpa()
+    for layer_cfg in cfg.layers:
+        if layer_cfg.moe is None:
+            continue
+        layer_cfg.moe.experts.compute_backend = "batched_mm_padded"
+        layer_cfg.moe.experts.use_grouped_mm = False
+    return cfg
+
+
 moe_configs = {
     "debugmodel": _debugmodel,
     "debugmodel_flex_attn": _debugmodel_flex_attn,
@@ -951,6 +962,7 @@ moe_configs = {
     "671B": _671b,
     "10B_2B": _10b_2b,
     "10B_2B_sdpa": _10b_2b_sdpa,
+    "10B_2B_sdpa_batched_mm_padded": _10b_2b_sdpa_batched_mm_padded,
 }
 
 moe_configs["debugmodel_hf"] = moe_configs["debugmodel"]

--- a/torchtitan/experiments/ezpz/moe/config_registry.py
+++ b/torchtitan/experiments/ezpz/moe/config_registry.py
@@ -296,6 +296,20 @@ def moe_10b_2b_sdpa() -> FaultTolerantTrainer.Config:
     return cfg
 
 
+def moe_10b_2b_sdpa_batched_mm_padded() -> FaultTolerantTrainer.Config:
+    cfg = moe(
+        "10B_2B_sdpa_batched_mm_padded",
+        local_batch_size=2,
+        activation_checkpoint_mode="none",
+    )
+    cfg.optimizer.lr = 2.2e-4
+    cfg.lr_scheduler.decay_type = "cosine"
+    cfg.lr_scheduler.min_lr_factor = 0.1
+    cfg.training.steps = 1000
+    cfg.checkpoint.interval = 100
+    return cfg
+
+
 def smoke_moe_500m_50steps() -> FaultTolerantTrainer.Config:
     """50-step moe smoke test for the post-#2963/#2937 replay.
 
@@ -338,6 +352,10 @@ def moe_16b_from_json() -> FaultTolerantTrainer.Config:
 
 def moe_10b_2b_from_json() -> FaultTolerantTrainer.Config:
     return _config_from_json(moe_10b_2b)
+
+
+def moe_10b_2b_sdpa_batched_mm_padded_from_json() -> FaultTolerantTrainer.Config:
+    return _config_from_json(moe_10b_2b_sdpa_batched_mm_padded)
 
 
 def moe_671b_from_json() -> FaultTolerantTrainer.Config:

--- a/torchtitan/models/common/config_utils.py
+++ b/torchtitan/models/common/config_utils.py
@@ -23,7 +23,12 @@ from torchtitan.models.common.attention import (
 )
 from torchtitan.models.common.feed_forward import FeedForward
 from torchtitan.models.common.linear import Linear
-from torchtitan.models.common.moe import GroupedExperts, MoE, TokenChoiceTopKRouter
+from torchtitan.models.common.moe import (
+    ExpertComputeBackend,
+    GroupedExperts,
+    MoE,
+    TokenChoiceTopKRouter,
+)
 from torchtitan.models.common.rmsnorm import RMSNorm
 from torchtitan.models.common.token_dispatcher import (
     AllToAllTokenDispatcher,
@@ -247,6 +252,7 @@ def make_experts_config(
     param_init: dict[str, Callable],
     score_before_experts: bool = True,
     use_grouped_mm: bool = True,
+    compute_backend: ExpertComputeBackend | None = None,
     comm_backend: str,
     non_blocking_capacity_factor: float | None = None,
 ) -> GroupedExperts.Config:
@@ -256,6 +262,7 @@ def make_experts_config(
         hidden_dim=hidden_dim,
         num_experts=num_experts,
         use_grouped_mm=use_grouped_mm,
+        compute_backend=compute_backend,
         param_init=param_init,
         token_dispatcher=make_token_dispatcher_config(
             num_experts=num_experts,

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -20,6 +20,9 @@ from torchtitan.protocols.module import Module
 from .token_dispatcher import LocalTokenDispatcher
 
 
+ExpertComputeBackend = Literal["for_loop", "grouped_mm", "batched_mm_padded"]
+
+
 # NOTE: keeping this for-loop implementation for comparison
 #       and readability, may remove later
 def _run_experts_for_loop(
@@ -53,6 +56,44 @@ def _run_experts_for_loop(
     return out
 
 
+def _run_experts_batched_mm_padded(
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    w3: torch.Tensor,
+    x: torch.Tensor,
+    num_tokens_per_expert: torch.Tensor,
+) -> torch.Tensor:
+    counts = num_tokens_per_expert.to(device=x.device, dtype=torch.int64)
+    if counts.numel() == 0:
+        return x.new_empty((0, w2.shape[1]))
+
+    max_tokens = int(counts.max().item())
+    if max_tokens == 0:
+        return x.new_empty((0, w2.shape[1]))
+
+    num_experts = counts.numel()
+    total_tokens = x.shape[0]
+    device = x.device
+
+    offsets = counts.cumsum(0) - counts
+    expert_indices = torch.repeat_interleave(
+        torch.arange(num_experts, device=device, dtype=torch.int64),
+        counts,
+    )
+    token_indices_within_expert = torch.arange(
+        total_tokens, device=device, dtype=torch.int64
+    ) - torch.repeat_interleave(offsets, counts)
+
+    padded_x = x.new_zeros((num_experts, max_tokens, x.shape[-1]))
+    padded_x[expert_indices, token_indices_within_expert] = x
+
+    h = F.silu(torch.bmm(padded_x, w1.transpose(-2, -1)))
+    h = h * torch.bmm(padded_x, w3.transpose(-2, -1))
+    out_padded = torch.bmm(h, w2.transpose(-2, -1))
+
+    return out_padded[expert_indices, token_indices_within_expert]
+
+
 def _run_experts_grouped_mm(
     w1: torch.Tensor,
     w2: torch.Tensor,
@@ -80,6 +121,7 @@ class GroupedExperts(Module):
         hidden_dim: int
         num_experts: int
         use_grouped_mm: bool = True
+        compute_backend: ExpertComputeBackend | None = None
         token_dispatcher: LocalTokenDispatcher.Config
 
     def __init__(self, config: Config):
@@ -94,7 +136,12 @@ class GroupedExperts(Module):
         self.w3 = nn.Parameter(
             torch.empty(config.num_experts, config.hidden_dim, config.dim)
         )
-        self.use_grouped_mm = config.use_grouped_mm
+        self.compute_backend: ExpertComputeBackend = (
+            config.compute_backend
+            if config.compute_backend is not None
+            else ("grouped_mm" if config.use_grouped_mm else "for_loop")
+        )
+        self.use_grouped_mm = self.compute_backend == "grouped_mm"
         self.token_dispatcher = config.token_dispatcher.build()
 
     def _experts_forward(
@@ -116,10 +163,15 @@ class GroupedExperts(Module):
             w2 = self.w2
             w3 = self.w3
 
-        if self.use_grouped_mm:
+        if self.compute_backend == "grouped_mm":
             return _run_experts_grouped_mm(w1, w2, w3, x, num_tokens_per_expert)
-        else:
+        if self.compute_backend == "batched_mm_padded":
+            return _run_experts_batched_mm_padded(
+                w1, w2, w3, x, num_tokens_per_expert
+            )
+        if self.compute_backend == "for_loop":
             return _run_experts_for_loop(w1, w2, w3, x, num_tokens_per_expert)
+        raise ValueError(f"Unknown expert compute backend: {self.compute_backend}")
 
     def forward(
         self,

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
@@ -21,6 +22,21 @@ from .token_dispatcher import LocalTokenDispatcher
 
 
 ExpertComputeBackend = Literal["for_loop", "grouped_mm", "batched_mm_padded"]
+ExpertComputeFn = Callable[
+    [torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+    torch.Tensor,
+]
+
+
+def _empty_expert_output(
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    w3: torch.Tensor,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    output = x.new_empty((0, w2.shape[1]))
+    # Preserve a zero-gradient path for empty expert inputs.
+    return output + (w1.sum() + w2.sum() + w3.sum() + x.sum()) * 0
 
 
 # NOTE: keeping this for-loop implementation for comparison
@@ -32,6 +48,9 @@ def _run_experts_for_loop(
     x: torch.Tensor,
     num_tokens_per_expert: torch.Tensor,
 ) -> torch.Tensor:
+    if num_tokens_per_expert.numel() == 0:
+        return _empty_expert_output(w1, w2, w3, x)
+
     # NOTE: this would incur a synchronization between device and host
     num_tokens_per_expert_list = num_tokens_per_expert.tolist()
 
@@ -56,6 +75,27 @@ def _run_experts_for_loop(
     return out
 
 
+def _compute_expert_layout(
+    counts: torch.Tensor,
+    total_tokens: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Map grouped routed tokens to padded expert rows.
+
+    ``x`` is expected to be grouped by expert, with ``counts`` giving each
+    expert's contiguous token count in the same order.
+    """
+    offsets = counts.cumsum(0) - counts
+    expert_indices = torch.repeat_interleave(
+        torch.arange(counts.numel(), device=device, dtype=torch.int64),
+        counts,
+    )
+    token_indices_within_expert = torch.arange(
+        total_tokens, device=device, dtype=torch.int64
+    ) - torch.repeat_interleave(offsets, counts)
+    return expert_indices, token_indices_within_expert
+
+
 def _run_experts_batched_mm_padded(
     w1: torch.Tensor,
     w2: torch.Tensor,
@@ -65,24 +105,19 @@ def _run_experts_batched_mm_padded(
 ) -> torch.Tensor:
     counts = num_tokens_per_expert.to(device=x.device, dtype=torch.int64)
     if counts.numel() == 0:
-        return x.new_empty((0, w2.shape[1]))
+        return _empty_expert_output(w1, w2, w3, x)
 
     max_tokens = int(counts.max().item())
     if max_tokens == 0:
-        return x.new_empty((0, w2.shape[1]))
+        return _empty_expert_output(w1, w2, w3, x)
 
     num_experts = counts.numel()
     total_tokens = x.shape[0]
     device = x.device
 
-    offsets = counts.cumsum(0) - counts
-    expert_indices = torch.repeat_interleave(
-        torch.arange(num_experts, device=device, dtype=torch.int64),
-        counts,
+    expert_indices, token_indices_within_expert = _compute_expert_layout(
+        counts, total_tokens, device
     )
-    token_indices_within_expert = torch.arange(
-        total_tokens, device=device, dtype=torch.int64
-    ) - torch.repeat_interleave(offsets, counts)
 
     padded_x = x.new_zeros((num_experts, max_tokens, x.shape[-1]))
     padded_x[expert_indices, token_indices_within_expert] = x
@@ -114,12 +149,20 @@ def _run_experts_grouped_mm(
     return out
 
 
+_EXPERT_COMPUTE_BACKENDS: dict[ExpertComputeBackend, ExpertComputeFn] = {
+    "grouped_mm": _run_experts_grouped_mm,
+    "batched_mm_padded": _run_experts_batched_mm_padded,
+    "for_loop": _run_experts_for_loop,
+}
+
+
 class GroupedExperts(Module):
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
         dim: int
         hidden_dim: int
         num_experts: int
+        # Backward-compatible legacy selector. Ignored when compute_backend is set.
         use_grouped_mm: bool = True
         compute_backend: ExpertComputeBackend | None = None
         token_dispatcher: LocalTokenDispatcher.Config
@@ -141,7 +184,6 @@ class GroupedExperts(Module):
             if config.compute_backend is not None
             else ("grouped_mm" if config.use_grouped_mm else "for_loop")
         )
-        self.use_grouped_mm = self.compute_backend == "grouped_mm"
         self.token_dispatcher = config.token_dispatcher.build()
 
     def _experts_forward(
@@ -163,15 +205,13 @@ class GroupedExperts(Module):
             w2 = self.w2
             w3 = self.w3
 
-        if self.compute_backend == "grouped_mm":
-            return _run_experts_grouped_mm(w1, w2, w3, x, num_tokens_per_expert)
-        if self.compute_backend == "batched_mm_padded":
-            return _run_experts_batched_mm_padded(
-                w1, w2, w3, x, num_tokens_per_expert
-            )
-        if self.compute_backend == "for_loop":
-            return _run_experts_for_loop(w1, w2, w3, x, num_tokens_per_expert)
-        raise ValueError(f"Unknown expert compute backend: {self.compute_backend}")
+        try:
+            compute_backend = _EXPERT_COMPUTE_BACKENDS[self.compute_backend]
+        except KeyError as e:
+            raise ValueError(
+                f"Unknown expert compute backend: {self.compute_backend}"
+            ) from e
+        return compute_backend(w1, w2, w3, x, num_tokens_per_expert)
 
     def forward(
         self,


### PR DESCRIPTION
## Summary

Adds a `batched_mm_padded` expert compute backend for MoE `GroupedExperts`.

The backend pads routed expert inputs to `[num_experts, max_tokens_per_expert, dim]`, uses `torch.bmm` for the SwiGLU expert projections, then gathers back to routed token order.

Default behavior is unchanged: if `compute_backend` is unset, the existing `use_grouped_mm` flag still selects grouped-mm vs for-loop. The new path is opt-in via `compute_backend="batched_mm_padded"`.

Also threads the backend selector through `make_experts_config`, adds an ezpz `10B_2B_sdpa_batched_mm_padded` flavor, and adds unit coverage comparing outputs and gradients against the for-loop implementation.

## Validation

- `git diff --cached --check`
- `/lus/flare/projects/AuroraGPT/sww/new_tt_aurora/torchtitan/.venv/bin/python -m py_compile torchtitan/models/common/moe.py torchtitan/models/common/config_utils.py torchtitan/experiments/ezpz/moe/__init__.py torchtitan/experiments/ezpz/moe/config_registry.py tests/unit_tests/test_moe_expert_backends.py`
- `PYTHONPATH=. timeout 300s /lus/flare/projects/AuroraGPT/sww/new_tt_aurora/torchtitan/.venv/bin/python -m unittest -v tests.unit_tests.test_moe_expert_backends`

## Summary by Sourcery

Add a new padded batched matmul expert compute backend for MoE GroupedExperts and wire it through configs and tests.

New Features:
- Introduce a batched_mm_padded expert compute backend for MoE GroupedExperts using padded batched matrix multiplications.
- Add a 10B_2B_sdpa_batched_mm_padded MoE configuration variant that uses the new backend.

Enhancements:
- Thread a generic expert compute_backend selector through GroupedExperts and make_experts_config while preserving existing default behavior.

Tests:
- Add unit tests to validate that the batched_mm_padded backend matches the for_loop implementation in outputs and gradients, and that backend selection in GroupedExperts behaves correctly.